### PR TITLE
Update dispatcher.go

### DIFF
--- a/pkg/proxy/dispatcher.go
+++ b/pkg/proxy/dispatcher.go
@@ -111,7 +111,7 @@ func newDispatcher(cnf *Cfg, db store.Store, runner *task.Runner) *dispatcher {
 
 func (r *dispatcher) dispatch(req *fasthttp.Request) []*dispathNode {
 	r.RLock()
-
+	defer r.RUnlock()
 	var dispathes []*dispathNode
 	for _, api := range r.apis {
 		if api.matches(req) {
@@ -129,7 +129,6 @@ func (r *dispatcher) dispatch(req *fasthttp.Request) []*dispathNode {
 		}
 	}
 
-	r.RUnlock()
 	return dispathes
 }
 


### PR DESCRIPTION
修复当tuntime.go的selectServer抛出异常时，读写锁r未释放，导致后续请求加锁hang住的问题
异常栈：
2018/01/29 13:25:32 panic: runtime error: invalid memory address or nil pointer
dereference
Stack trace:
goroutine 12080 [running]:
runtime/debug.Stack(0xc0420358a8, 0x9d4760, 0xe21080)
        D:/Go/src/runtime/debug/stack.go:24 +0xae
github.com/fagongzi/gateway/vendor/github.com/valyala/fasthttp.(*workerPool).wor
kerFunc.func1(0xc0422d0200, 0xc042035f68)
        D:/goprojects/src/github.com/fagongzi/gateway/vendor/github.com/valyala/
fasthttp/workerpool.go:207 +0x95
panic(0x9d4760, 0xe21080)
        D:/Go/src/runtime/panic.go:491 +0x291
github.com/fagongzi/gateway/pkg/proxy.(*clusterRuntime).selectServer(0x0, 0xc042
52c000, 0x0)
        D:/goprojects/src/github.com/fagongzi/gateway/pkg/proxy/runtime.go:66 +0
x2d
github.com/fagongzi/gateway/pkg/proxy.(*dispatcher).selectServer(0xc042044d20, 0
xc04252c000, 0x0, 0xe53dc0)
        D:/goprojects/src/github.com/fagongzi/gateway/pkg/proxy/dispatcher.go:15
1 +0x3c
github.com/fagongzi/gateway/pkg/proxy.(*dispatcher).routingOpt(0xc042044d20, 0xc
04252c000, 0xc0422d4000)
        D:/goprojects/src/github.com/fagongzi/gateway/pkg/proxy/dispatcher.go:14
1 +0x143
github.com/fagongzi/gateway/pkg/proxy.(*dispatcher).dispatch(0xc042044d20, 0xc04
252c000, 0x0, 0x0, 0x0)
        D:/goprojects/src/github.com/fagongzi/gateway/pkg/proxy/dispatcher.go:12
5 +0x2af
github.com/fagongzi/gateway/pkg/proxy.(*Proxy).ReverseProxyHandler(0xc0421300c0,
 0xc04252c000)
        D:/goprojects/src/github.com/fagongzi/gateway/pkg/proxy/proxy.go:250 +0x
69
github.com/fagongzi/gateway/pkg/proxy.(*Proxy).ReverseProxyHandler-fm(0xc04252c0
00)
        D:/goprojects/src/github.com/fagongzi/gateway/pkg/proxy/proxy.go:100 +0x
3b
github.com/fagongzi/gateway/vendor/github.com/valyala/fasthttp.(*Server).serveCo
nn(0xc04235f2c0, 0xdebe40, 0xc0422f8018, 0xc042035e01, 0x101)
        D:/goprojects/src/github.com/fagongzi/gateway/vendor/github.com/valyala/
fasthttp/server.go:1494 +0x618
github.com/fagongzi/gateway/vendor/github.com/valyala/fasthttp.(*Server).(github
.com/fagongzi/gateway/vendor/github.com/valyala/fasthttp.serveConn)-fm(0xdebe40,
 0xc0422f8018, 0xc0422d0201, 0xc042035f68)
        D:/goprojects/src/github.com/fagongzi/gateway/vendor/github.com/valyala/
fasthttp/server.go:1223 +0x45
github.com/fagongzi/gateway/vendor/github.com/valyala/fasthttp.(*workerPool).wor
kerFunc(0xc0422d0200, 0xc04211cde0)
        D:/goprojects/src/github.com/fagongzi/gateway/vendor/github.com/valyala/
fasthttp/workerpool.go:224 +0x14b
github.com/fagongzi/gateway/vendor/github.com/valyala/fasthttp.(*workerPool).get
Ch.func1(0xc0422d0200, 0xc04211cde0, 0x97e3a0, 0xc04211cde0)
        D:/goprojects/src/github.com/fagongzi/gateway/vendor/github.com/valyala/
fasthttp/workerpool.go:183 +0x3c
created by github.com/fagongzi/gateway/vendor/github.com/valyala/fasthttp.(*work
erPool).getCh
        D:/goprojects/src/github.com/fagongzi/gateway/vendor/github.com/valyala/
fasthttp/workerpool.go:182 +0x143

