### PR TITLE
删除不必要的层，减少 Docker 镜像大小

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:latest
 
-RUN mkdir -p /app/gateway
 RUN mkdir -p /app/gateway/plugins
 
 ADD ./dist/proxy /app/gateway


### PR DESCRIPTION
man mkdir :
-p      Create intermediate directories as required.

-p option 会自动创建路径中间必要的文件夹，没必要执行两次 mkdir , 反而增加 Docker image 层数，导致镜像变大。