### PR TITLE
fix: routing is still available when down

### DIFF
--- a/pkg/proxy/dispatcher.go
+++ b/pkg/proxy/dispatcher.go
@@ -248,7 +248,7 @@ func (r *dispatcher) selectServer(req *fasthttp.Request, dn *dispathNode) {
 
 func (r *dispatcher) adjustByRouting(apiID uint64, req *fasthttp.Request, dn *dispathNode) {
 	for _, routing := range r.routings {
-		if routing.matches(apiID, req) {
+		if routing.isUp() && routing.matches(apiID, req) {
 			svr := r.selectServerFromCluster(req, routing.meta.ClusterID)
 
 			switch routing.meta.Strategy {

--- a/pkg/proxy/runtime.go
+++ b/pkg/proxy/runtime.go
@@ -557,6 +557,10 @@ func (a *routingRuntime) matches(apiID uint64, req *fasthttp.Request) bool {
 	return n < int(a.meta.TrafficRate)
 }
 
+func (a *routingRuntime) isUp() bool {
+	return a.meta.Status == metapb.Up
+}
+
 func conditionsMatches(cond *metapb.Condition, req *fasthttp.Request) bool {
 	attrValue := paramValue(&cond.Parameter, req)
 	if attrValue == "" {


### PR DESCRIPTION
routing状态为down时仍然可用，因此加入对其状态的判断。