### PR TITLE
解决请求成功率失败率等metric值超过100%问题

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -333,7 +333,6 @@ func (p *Proxy) ServeFastHTTP(ctx *fasthttp.RequestCtx) {
 		api.meta.Name,
 		len(dispatches))
 
-	incrRequest(api.meta.Name)
 
 	rd := acquireRender()
 	rd.init(requestTag, api, dispatches)
@@ -402,6 +401,7 @@ func (p *Proxy) ServeFastHTTP(ctx *fasthttp.RequestCtx) {
 	releaseRender(rd)
 	releaseMultiContext(multiCtx)
 
+	incrRequest(api.meta.Name)
 	p.postRequest(api, dispatches, startAt)
 
 	log.Debugf("%s: dispatch complete",


### PR DESCRIPTION
incrRequest和p.postRequest 分别放在doproxy方法前后会造成同一请求的在同一时刻的请求数和成功数不幂等，比如长耗时类的请求很容易出现请求成功率在100%上下浮动，两个方法放在一起回极大减少这种情况，