### PR TITLE
fasthttp.Server limit 参数试用proxy设置的参数

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -123,7 +123,13 @@ func (p *Proxy) Start() {
 	log.Infof("gateway proxy started at <%s>", p.cfg.Addr)
 
 	if !p.cfg.Option.EnableWebSocket {
-		err := fasthttp.ListenAndServe(p.cfg.Addr, p.ServeFastHTTP)
+		httpServer := fasthttp.Server{
+			Handler:            p.ServeFastHTTP,
+			ReadBufferSize:     p.cfg.Option.LimitBufferRead,
+			WriteBufferSize:    p.cfg.Option.LimitBufferWrite,
+			MaxRequestBodySize: p.cfg.Option.LimitBytesBody,
+		}
+		err := httpServer.ListenAndServe(p.cfg.Addr)
 		if err != nil {
 			log.Fatalf("gateway proxy start failed, errors:\n%+v",
 				err)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -143,7 +143,10 @@ func (p *Proxy) Start() {
 
 	go func() {
 		httpS := fasthttp.Server{
-			Handler: p.ServeFastHTTP,
+			Handler:            p.ServeFastHTTP,
+			ReadBufferSize:     p.cfg.Option.LimitBufferRead,
+			WriteBufferSize:    p.cfg.Option.LimitBufferWrite,
+			MaxRequestBodySize: p.cfg.Option.LimitBytesBody,
 		}
 		err = httpS.Serve(httpL)
 		if err != nil {


### PR DESCRIPTION
fasthttp.Server limit 相关参数使用proxy设置的对应参数
limit-buf-read
limit-buf-write
limit-buf-write

场景如下：
crash.log 发下如下报错
small read buffer. Increase ReadBufferSize
经追踪发现fasthttp.Server.ReadBufferSize 没有设置 导致使用默认值defaultReadBufferSize=4096

